### PR TITLE
Get the package version from git tags for conda package builds

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -1,0 +1,39 @@
+name: httomolib nightly conda package build
+
+on:
+  schedule:
+    # Run at midnight every day
+    - cron: '0 0 * * *'
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v3
+        with:
+          ref: "main"
+          fetch-depth: 0
+
+      # setup Python 3.9
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Decrypt a secret
+        run: ./.scripts/decrypt_secret.sh
+        env:
+          LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+
+      - name: Build and upload the tested package to httomo conda cloud
+        env:
+          LABEL: dev
+        run: |
+          chmod +x ./.scripts/conda_upload.sh
+          ./.scripts/conda_upload.sh

--- a/.github/workflows/tests_upload.yml
+++ b/.github/workflows/tests_upload.yml
@@ -46,6 +46,8 @@ jobs:
           LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
       - name: Build and upload the tested package to httomo conda cloud
+        env:
+          LABEL: main
         run: |
           chmod +x ./.scripts/conda_upload.sh
           ./.scripts/conda_upload.sh

--- a/.github/workflows/tests_upload.yml
+++ b/.github/workflows/tests_upload.yml
@@ -18,7 +18,9 @@ jobs:
 
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # setup Python 3.9
       - name: Setup Python 3.9

--- a/.github/workflows/tests_upload.yml
+++ b/.github/workflows/tests_upload.yml
@@ -1,12 +1,10 @@
 name: httomolib tests and conda upload
 
+# Run the workflow whenever a tag beginning with `v` is pushed to any branch
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    tags:
+      - v*
 
 jobs:
   build-linux:

--- a/.github/workflows/tests_upload.yml
+++ b/.github/workflows/tests_upload.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
       # setup Python 3.9
       - name: Setup Python 3.9

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# These are files that are created during the conda build process that need to
+# be ignored in order to avoid builds being marked as being in a "dirty" state
+build_env_setup.sh
+conda_build.sh
+metadata_conda_debug.yaml

--- a/.scripts/conda_upload.sh
+++ b/.scripts/conda_upload.sh
@@ -25,5 +25,5 @@ $CONDA/bin/conda build . -c conda-forge -c httomo
 find $CONDA_BLD_PATH/$OS -name *.tar.bz2 | while read file
 do
     echo $file
-    $CONDA/bin/anaconda -v --show-traceback --token $CONDA_TOKEN upload $file --force
+    $CONDA/bin/anaconda -v --show-traceback --token $CONDA_TOKEN upload --label $LABEL $file --force
 done

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -15,5 +15,6 @@ dependencies:
   - conda-forge::pydocstyle
   - conda-forge::imageio
   - conda-forge::toml
+  - conda-forge::setuptools-git-versioning
   - anaconda::ipython
   - httomo::larix

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: {{ name|lower }}
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ GIT_DESCRIBE_TAG|trim("v") }}
 
 source:
   path: ../../

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,11 +1,10 @@
 {% set pyproject = load_file_data("../../pyproject.toml", from_recipe_dir=True) %}
 {% set proj = pyproject.get("project") %}
 {% set name = proj.get("name") %}
-{% set version = proj.get("version") %}
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   path: ../../
@@ -19,6 +18,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - setuptools-git-versioning
   run:
     - python
     - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ packages = ["httomolib",
 
 [tool.setuptools-git-versioning]
 enabled = true
+template = "{tag}"
+dev_template = "{tag}"
 
 [project]
 name = "httomolib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
   "pydocstyle",
   "toml",
   "imageio",
+  "setuptools-git-versioning",
 ]
 
 [project.urls]


### PR DESCRIPTION
To provide some examples of what the package version generated from the git tag will be, assume that the tag is of the form `v1.0.0`.

What these changes do at the moment is:
- when building on the commit with that tag, the package version will be of the form `1.0.0`
- when building on a commit that comes _after_ the commit tagged `v1.0.0` but _before_ another tagged commit, the package version built will be of the form `1.0.0+post{N}+git.{COMMIT_ID}`, where `{N}` is the same value as the `build_number` in the `meta.yaml` https://github.com/DiamondLightSource/httomolib/blob/version-from-tag/conda/recipe/meta.yaml#L14, and `{COMMIT_ID}` is the 8-character shortened version of the commit SHA that the package was built from
  - the `build_number` is incremented for each build done on an untagged commit
  - so, if three builds were done on different commits _after_ the `v1.0.0` commit and _before_ any other tagged commit, those package builds would have versions `1.0.0+post1+git.{COMMIT_ID}`, `1.0.0+post2+git.{COMMIT_ID}`, and `1.0.0+post3+git.{COMMIT_ID}` respectively (or maybe it starts counting from 0, I'm not sure about that, but you hopefully get the gist)
