### PR TITLE
Make rescaling images to integer range optional  + optimise

### DIFF
--- a/httomolib/misc/images.py
+++ b/httomolib/misc/images.py
@@ -74,7 +74,7 @@ def save_to_images(
     jpeg_quality : int, optional
         Specify the quality of the jpeg image.
     glob_stats: tuple, optional
-        Global statistics of the input data in a tuple format: (min, max, mean, std_var).
+        Global statistics of the input data in a tuple format: (min, max, mean, total_elements_number).
         If None, then it will be calculated.
     offest: int, optional
         The offset to start file indexing from, e.g. if offset is 100, images will start at

--- a/httomolib/misc/images.py
+++ b/httomolib/misc/images.py
@@ -47,7 +47,9 @@ def save_to_images(
     offset: int = 0,
 ):
     """
-    Saves data as 2D images.
+    Saves data as 2D images. If the data type is not already one of the integer types
+    uint8, uint16, or uint32, the data is rescaled and converted first.
+    Otherwise it leaves the data as is.
 
     Parameters
     ----------
@@ -66,84 +68,94 @@ def save_to_images(
     bits : int, optional
         Specify the number of bits to use (8, 16, or 32-bit).
     perc_range_min: float, optional
-        Using `np.percentile` to scale data in percentage range.
+        lower cutoff point: min + perc_range_min * (max-min)/100
         Defaults to 0.0
     perc_range_max: float, optional
-        Using `np.percentile` to scale data in percentage range.
+        upper cutoff point: min + perc_range_max * (max-min)/100
         Defaults to 100.0
     jpeg_quality : int, optional
         Specify the quality of the jpeg image.
     glob_stats: tuple, optional
         Global statistics of the input data in a tuple format: (min, max, mean, total_elements_number).
-        If None, then it will be calculated.
+        If None, then it will be calculated based on the input data.
     offest: int, optional
         The offset to start file indexing from, e.g. if offset is 100, images will start at
         00100.tif. This is used when executed in parallel context and only partial data is 
         passed in this run. 
     """
-
-    if bits not in [8, 16, 32]:
-        bits = 32
-        print(
-            "The selected bit type %s is not available, "
-            "resetting to 32 bit \n" % str(bits)
-        )
+    if data.dtype in [np.uint8, np.uint16, np.uint32]:
+        # do not touch the data if it's already in integers, but set the bits in order to 
+        # create the right folder
+        bits = data.dtype.itemsize * 8
+    elif bits not in [8, 16, 32]:
+            bits = 32
+            print(
+                "The selected bit type %s is not available, "
+                "resetting to 32 bit \n" % str(bits)
+            )
 
     # create the output folder
     subsubfolder_name = f"images{str(bits)}bit_{str(file_format)}"
     path_to_images_dir = pathlib.Path(out_dir) / subfolder_name / subsubfolder_name
     path_to_images_dir.mkdir(parents=True, exist_ok=True)
 
-    data = np.nan_to_num(data, copy=False, nan=0.0, posinf=0, neginf=0)
-    
-    if glob_stats is None or glob_stats is False:
-        min_percentile = np.nanpercentile(data, perc_range_min)
-        max_percentile = np.nanpercentile(data, perc_range_max)
-    else:
-        # calculate the range here based on global max and min
-        range_intensity = glob_stats[1] - glob_stats[0]
-        min_percentile = (perc_range_min * (range_intensity) / 100) + glob_stats[0]
-        max_percentile = (perc_range_max * (range_intensity) / 100) + glob_stats[0]
+    do_rescale = False
+    if data.dtype not in [np.uint8, np.uint16, np.uint32]:
+        do_rescale = True
+        
+        
+        data = np.nan_to_num(data, copy=False, nan=0.0, posinf=0, neginf=0)
+        
+        if glob_stats is None or glob_stats is False:
+            min_percentile = np.nanpercentile(data, perc_range_min)
+            max_percentile = np.nanpercentile(data, perc_range_max)
+        else:
+            # calculate the range here based on global max and min
+            range_intensity = glob_stats[1] - glob_stats[0]
+            min_percentile = (perc_range_min * (range_intensity) / 100) + glob_stats[0]
+            max_percentile = (perc_range_max * (range_intensity) / 100) + glob_stats[0]
 
     if data.ndim == 3:
         slice_dim_size = np.shape(data)[axis]
         for idx in range(slice_dim_size):
+            
             filename = f"{idx + offset:05d}.{file_format}"
             filepath = os.path.join(path_to_images_dir, f"{filename}")
-            _save_single_img(
-                data.take(indices=idx, axis=axis),
-                min_percentile,
-                max_percentile,
-                bits,
-                jpeg_quality,
-                filepath,
-            )
+            # note: data.take call is far more time consuming
+            if axis == 0:
+                d = data[idx, :, :] 
+            elif axis == 1:
+                d = data[:, idx, :] 
+            else:
+                d = data[:, :, idx]
+                
+            if do_rescale:
+                d = _rescale_2d(d, bits, min_percentile, max_percentile)
+            
+            Image.fromarray(d).save(filepath, quality=jpeg_quality)
+
     else:
         filename = f"{1:05d}.{file_format}"
         filepath = os.path.join(path_to_images_dir, f"{filename}")
-        _save_single_img(data, min_percentile, max_percentile, bits, jpeg_quality, filepath)
+        if do_rescale:
+                data = _rescale_2d(data, bits, min_percentile, max_percentile)
+        Image.fromarray(data).save(filepath, quality=jpeg_quality)
 
-def _save_single_img(array2d,
-                     min_percentile,
-                     max_percentile,
-                     bits, 
-                     jpeg_quality, 
-                     path_to_out_file):
-    """Rescales to the bit chosen and saves the image."""
+
+def _rescale_2d(d: np.ndarray, bits: int, min_percentile, max_percentile):
     if bits == 8:
-        array2d = exposure.rescale_intensity(
-            array2d, in_range=(min_percentile, max_percentile), out_range=(0, 255)
+        d = exposure.rescale_intensity(
+            d, in_range=(min_percentile, max_percentile), out_range=(0, 255)
         ).astype(np.uint8)
 
     elif bits == 16:
-        array2d = exposure.rescale_intensity(
-            array2d, in_range=(min_percentile, max_percentile), out_range=(0, 65535)
+        d = exposure.rescale_intensity(
+            d, in_range=(min_percentile, max_percentile), out_range=(0, 65535)
         ).astype(np.uint16)
 
     else:
-        array2d = exposure.rescale_intensity(
-            array2d, in_range=(min_percentile, max_percentile), out_range=(min_percentile, max_percentile)
+        d = exposure.rescale_intensity(
+            d, in_range=(min_percentile, max_percentile), out_range=(min_percentile, max_percentile)
         ).astype(np.uint32)
-
-    img = Image.fromarray(array2d)
-    img.save(path_to_out_file, quality=jpeg_quality)
+        
+    return d

--- a/tests/test_misc/test_images.py
+++ b/tests/test_misc/test_images.py
@@ -1,36 +1,74 @@
 import pathlib
 
 import numpy as np
+import pytest
 from httomolib.misc.images import save_to_images
 from PIL import Image
 
 
-def test_save_to_images_8bit(host_data, tmp_path: pathlib.Path):
+@pytest.mark.parametrize("bits", [8, 16, 32])
+def test_save_to_images(host_data: np.ndarray, tmp_path: pathlib.Path, bits: int):
     # --- Test for bits=8
-    save_to_images(host_data, tmp_path / "save_to_images", bits=8)
-    #: check that the folder is created
+    save_to_images(host_data[:, :10, :], tmp_path / "save_to_images", bits=bits)
+
+    folder = tmp_path / "save_to_images" / "images" / f"images{bits}bit_tif"
+    assert folder.exists()
+    files = list(folder.glob("*"))
+
+    assert len(files) == 10
+    for f in files:
+        assert f.name[-3:] == "tif"
+        assert Image.open(f).size == (host_data.shape[2], host_data.shape[0])
+
+
+def test_save_to_images_2D(host_data: np.ndarray, tmp_path: pathlib.Path):
+    save_to_images(
+        np.squeeze(host_data[:, 1, :]),
+        tmp_path / "save_to_images",
+        bits=8,
+        file_format="tif",
+    )
+
     folder = tmp_path / "save_to_images" / "images" / "images8bit_tif"
     assert folder.exists()
+    files = [f.name for f in folder.glob("*")]
 
-    nfiles = len(list(folder.glob("*")))
-    assert nfiles == 128  #: check that the number of files is correct
-    assert len(list(folder.glob("*.tif"))) == nfiles  #: check that all files are tif
-
-    #: check that the image size is correct
-    imarray = np.array(Image.open(folder / "00015.tif"))
-    assert imarray.shape == (180, 160)
+    assert files == ["00001.tif"]
 
 
-def test_save_to_images_4423bit(host_data, tmp_path: pathlib.Path):
-    # --- Test for bits=4423
+@pytest.mark.parametrize("offset", [0, 10, 35])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_save_to_images_offset_axis(
+    host_data: np.ndarray, tmp_path: pathlib.Path, offset: int, axis: int
+):
     save_to_images(
-        host_data,
+        host_data[:10, :10, :10],
+        tmp_path / "save_to_images",
+        bits=8,
+        offset=offset,
+        file_format="tif",
+        axis=axis,
+    )
+
+    folder = tmp_path / "save_to_images" / "images" / "images8bit_tif"
+    assert folder.exists()
+    # convert file names without extension to numbers and sort them
+    files = sorted([int(f.name[:-4]) for f in folder.glob("*")])
+
+    assert len(files) == 10
+    assert files == list(range(offset, offset + len(files)))
+
+
+@pytest.mark.parametrize("bits", [19, 242, 4432])
+def test_save_to_images_other_bits_default_to_32(host_data, tmp_path: pathlib.Path, bits: int):
+    save_to_images(
+        host_data[:, 1:3, :],
         tmp_path / "save_to_images",
         subfolder_name="test",
         file_format="png",
-        bits=4423,
+        bits=bits,
     )
 
     folder = tmp_path / "save_to_images" / "test" / "images32bit_png"
     assert folder.exists()
-    assert len(list(folder.glob("*.png"))) == 128
+    assert len(list(folder.glob("*.png"))) == 2


### PR DESCRIPTION
This PR modifies `save_to_images` to only rescale the data if the inputs are not already in integer format. It further optimises the performance by removing the very slow call to `data.take`.

**Note:** This PR should be merged after the other one for adding the offset parameter, as it was branched off the other change.